### PR TITLE
Revert "Revert "Remove unnecessary recursive find & replace using grep & sed in build workflow""

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -60,9 +60,6 @@ jobs:
           key: hugo-${{ github.run_id }}
           restore-keys:
             hugo-
-      - name: On the fly path replacement for images
-        run: |
-          grep -rl "/images/" ./content | xargs sed -i s@"/images/"@"/Winutil-docs/images/"@g
       - name: Build with Hugo
         run: |
           hugo \


### PR DESCRIPTION
## Description
Reverts Chris-Titus-Docs/winutil-docs#25

## Explanation/Story behind all of these actions
We trying to figure out why the URLs for images are not working properly, and the reason was "maybe the docs wasn't updated correctly when migrated from winutil repo to here", and indeed some were, but pretty much all the images doesn't work, so I turned into workflow file for building & deploying the website.

Noticed this step acting a little weird.. which's changing all "/images/" into "/Winutil-docs/images/", which I believe is some old code (idk how old, but at the current state the images are broken.. and it might be this step), to test my hypothesis, I tried removing it (#24).. but to no avail, so I decided to revert the changes (#25).

After taking a closer look, I noticed the workflow was smartly caching build result of the website (found in `hugo_cache` directory), and then I thought.. could it be that the caches are old, or more precisely, using older results that contains the `/Winutil-docs/images/` in Images URL links.. and to test this theory of mine, I've deleted every cache that was made in the last 3 hours (at the time of writing the oldest was 3hrs), and made this PR.

------

**EDIT**: Success!! 🥳🎊
![image](https://github.com/user-attachments/assets/a9616ba2-3ac2-4ad6-ac9f-f57a47404fe0)