### PR TITLE
Fixed incorrect indexing of default tab under UserGuide -> Store page

### DIFF
--- a/content/userguide/store/_index.md
+++ b/content/userguide/store/_index.md
@@ -3,7 +3,7 @@ title: Store
 weight: 2
 ---
 
-{{< tabs items="Installation & Updates,Upgrade All,Uninstall,Get Installed,Clear Selection" defaultIndex="1" >}}
+{{< tabs items="Installation & Updates,Upgrade All,Uninstall,Get Installed,Clear Selection" defaultIndex="0" >}}
 
   {{< tab >}}
     * Choose the programs you want to install or upgrade.


### PR DESCRIPTION
## Description from the commit
tabs shortcode 'defaultIndex' parameter is zero-based index, so the first tab in the tabs list is 0