### PR TITLE
Add image optimizations to image shortcode

### DIFF
--- a/layouts/shortcodes/image.html
+++ b/layouts/shortcodes/image.html
@@ -1,40 +1,44 @@
+{{/*Retrive Passed Shortcode Parameters*/}}
 {{ $src := .Get "src" }}
 {{ $alt := .Get "alt" }}
 
-{{ $DarkSrc := "" }}
-{{ $LightSrc := "" }}
-{{ $SingleSrc := "" }}
+{{/*Define variables as global variables to make them accessable in this shortcode*/}}
+{{ $DarkImage := "" }}
+{{ $LightImage := "" }}
+{{ $SingleImage := "" }}
 
-{{ $DarkSrcPng := (print $src "-Dark" ".png") }}
-{{ $LightSrcPng := (print $src "-Light" ".png") }}
-{{ $SingleSrcPng := (print $src ".png") }}
-{{ $DarkSrcJpg := (print $src "-Dark" ".jpg") }}
-{{ $LightSrcJpg := (print $src "-Light" ".jpg") }}
-{{ $SingleSrcJpg := (print $src ".jpg") }}
-
-{{ with resources.GetMatch ($DarkSrcJpg) }} {{ $DarkSrc = ($DarkSrcJpg) }} {{ end }}
-{{ with resources.GetMatch ($LightSrcJpg) }} {{ $LightSrc = ($LightSrcJpg) }} {{ end }}
-{{ with resources.GetMatch ($SingleSrcJpg) }} {{ $SingleSrc = ($SingleSrcJpg) }} {{ end }}
-{{ with resources.GetMatch ($DarkSrcPng) }} {{ $DarkSrc = ($DarkSrcPng) }} {{ end }}
-{{ with resources.GetMatch ($LightSrcPng) }} {{ $LightSrc = ($LightSrcPng) }} {{ end }}
-{{ with resources.GetMatch ($SingleSrcPng) }} {{ $SingleSrc = ($SingleSrcPng) }} {{ end }}
+{{/*Find images and update the previous Single,Dark,Light Images variables*/}}
+{{ with resources.GetMatch (print $src "-Dark" ".jpg") }} {{ $DarkImage = . }} {{ end }}
+{{ with resources.GetMatch (print $src "-Light" ".jpg") }} {{ $LightImage = . }} {{ end }}
+{{ with resources.GetMatch (print $src ".jpg") }} {{ $SingleImage = . }} {{ end }}
+{{ with resources.GetMatch (print $src "-Dark" ".png") }} {{ $DarkImage = . }} {{ end }}
+{{ with resources.GetMatch (print $src "-Light" ".png") }} {{ $LightImage = . }} {{ end }}
+{{ with resources.GetMatch (print $src ".png") }} {{ $SingleImage = . }} {{ end }}
 
 
+{{ if $SingleImage }}
+    <img {{ with $SingleImage }}
+        src="{{ .RelPermalink }}"
+        width="{{ .Width }}"
+        height="{{ .Height }}"
+        {{end}}{{ with $alt }}alt="{{.}}"{{ else }}alt=""{{ end }}/>
+{{ else }}
 <picture>
-    {{ with resources.GetMatch ($SingleSrc) }}<source srcset="{{ .RelPermalink }}">{{ end }}
-    {{ with resources.GetMatch ($DarkSrc) }}<source srcset="{{ .RelPermalink }}" media="(prefers-color-scheme: dark)">{{ end }}
-    {{ with resources.GetMatch ($LightSrc) }}<source srcset="{{ .RelPermalink }}" media="(prefers-color-scheme: light)">{{ end }}
-    <img {{ with resources.GetMatch ($SingleSrc) }}
+    {{ with $SingleImage }}<source srcset="{{ .RelPermalink }}">{{ end }}
+    {{ with $DarkImage }}<source srcset="{{ .RelPermalink }}" media="(prefers-color-scheme: dark)">{{ end }}
+    {{ with $LightImage }}<source srcset="{{ .RelPermalink }}" media="(prefers-color-scheme: light)">{{ end }}
+    <img {{ with $SingleImage }}
         src="{{ .RelPermalink }}"
         Width="{{ .Width }}"
         height="{{ .Height }}"
-    {{ else with resources.GetMatch ($DarkSrc) }}
+        {{ else with $LightImage }}
         src="{{ .RelPermalink }}"
         Width="{{ .Width }}"
         height="{{ .Height }}"
-    {{ else with resources.GetMatch ($DarkSrc) }}
+        {{ else with $DarkImage }}
         src="{{ .RelPermalink }}"
         Width="{{ .Width }}"
         height="{{ .Height }}"
-    {{ end }}{{ with .Get "alt" }}alt="{{.}}"{{ else }}alt=""{{ end }}/>
+        {{ end }}{{ with $alt }}alt="{{.}}"{{ else }}alt=""{{ end }}/>
 </picture>
+{{ end }}

--- a/layouts/shortcodes/image.html
+++ b/layouts/shortcodes/image.html
@@ -8,12 +8,29 @@
 {{ $SingleImage := "" }}
 
 {{/*Find images and update the previous Single,Dark,Light Images variables*/}}
+{{ with resources.GetMatch (print $src ".jpg") }} {{ $SingleImage = . }} {{ end }}
 {{ with resources.GetMatch (print $src "-Dark" ".jpg") }} {{ $DarkImage = . }} {{ end }}
 {{ with resources.GetMatch (print $src "-Light" ".jpg") }} {{ $LightImage = . }} {{ end }}
-{{ with resources.GetMatch (print $src ".jpg") }} {{ $SingleImage = . }} {{ end }}
+{{ with resources.GetMatch (print $src ".png") }} {{ $SingleImage = . }} {{ end }}
 {{ with resources.GetMatch (print $src "-Dark" ".png") }} {{ $DarkImage = . }} {{ end }}
 {{ with resources.GetMatch (print $src "-Light" ".png") }} {{ $LightImage = . }} {{ end }}
-{{ with resources.GetMatch (print $src ".png") }} {{ $SingleImage = . }} {{ end }}
+
+{{/*Applying Image Processing*/}}
+{{ with $SingleImage }}
+    {{ with .Resize (printf "%dx%d webp" .Width .Height) }}
+        {{ $SingleImage = . }}
+    {{ end }}
+{{ end }}
+{{ with $DarkImage }}
+    {{ with .Resize (printf "%dx%d webp" .Width .Height) }}
+        {{ $DarkImage = . }}
+    {{ end }}
+{{ end }}
+{{ with $LightImage }}
+    {{ with .Resize (printf "%dx%d webp" .Width .Height) }}
+        {{ $LightImage = . }}
+    {{ end }}
+{{ end }}
 
 
 {{ if $SingleImage }}

--- a/layouts/shortcodes/image.html
+++ b/layouts/shortcodes/image.html
@@ -34,28 +34,16 @@
 
 
 {{ if $SingleImage }}
-    <img {{ with $SingleImage }}
-        src="{{ .RelPermalink }}"
-        width="{{ .Width }}"
-        height="{{ .Height }}"
-        {{end}}{{ with $alt }}alt="{{.}}"{{ else }}alt=""{{ end }}/>
+    <img src="{{ $SingleImage.RelPermalink }}" Width="{{ $SingleImage.Width }}" height="{{ $SingleImage.Height }}" {{ with $alt }}alt="{{.}}"{{ else }}alt=""{{ end }}/>
 {{ else }}
 <picture>
     {{ with $SingleImage }}<source srcset="{{ .RelPermalink }}">{{ end }}
     {{ with $DarkImage }}<source srcset="{{ .RelPermalink }}" media="(prefers-color-scheme: dark)">{{ end }}
     {{ with $LightImage }}<source srcset="{{ .RelPermalink }}" media="(prefers-color-scheme: light)">{{ end }}
-    <img {{ with $SingleImage }}
-        src="{{ .RelPermalink }}"
-        Width="{{ .Width }}"
-        height="{{ .Height }}"
-        {{ else with $LightImage }}
-        src="{{ .RelPermalink }}"
-        Width="{{ .Width }}"
-        height="{{ .Height }}"
-        {{ else with $DarkImage }}
-        src="{{ .RelPermalink }}"
-        Width="{{ .Width }}"
-        height="{{ .Height }}"
-        {{ end }}{{ with $alt }}alt="{{.}}"{{ else }}alt=""{{ end }}/>
+
+    {{ with $SingleImage }}<img src="{{ .RelPermalink }}" Width="{{ .Width }}" height="{{ .Height }}" {{ with $alt }}alt="{{.}}"{{ else }}alt=""{{ end }}/>
+    {{ else with $LightImage }}<img src="{{ .RelPermalink }}" Width="{{ .Width }}" height="{{ .Height }}" {{ with $alt }}alt="{{.}}"{{ else }}alt=""{{ end }}/>
+    {{ else with $DarkImage }}<img src="{{ .RelPermalink }}" Width="{{ .Width }}" height="{{ .Height }}" {{ with $alt }}alt="{{.}}"{{ else }}alt=""{{ end }}/>
+    {{ end }}
 </picture>
 {{ end }}


### PR DESCRIPTION
## Commit History (Oldest to Newest)
- 76de4bb Simplify image shortcode and Improve generated HTML for single image use case
- ccc2dc7 Implement the image optimization feature using Convertion to webp format in image shortcode
- 41ff6ae Make generated HTML more compact at the expense of Image Shortcode's Readability

## Benchmarking
As far as I can tell, the image quality is the same.. at least in theory, haven't made a one for one comparison between original files, and generated webp files, so it may or may not be lossless convertion.

For the file size, it's an average of 71% reduction in image sizes when compared to original files (in `.png` format)
![image](https://github.com/user-attachments/assets/7772483a-5e09-412c-9f77-61b3f9f7aeb8)
![image](https://github.com/user-attachments/assets/854541bf-0296-4223-a894-3718e4304f77)

## Future improvements
We could reduce the file size even further, but at the expense of quality ([more info here](https://gohugo.io/content-management/image-processing/#quality)). But for now, I'm happy with these optimizations :3