### PR TITLE
Add support for generating different sized images for different display sizes in image shortcode

### DIFF
--- a/layouts/shortcodes/image.html
+++ b/layouts/shortcodes/image.html
@@ -2,10 +2,15 @@
 {{ $src := .Get "src" }}
 {{ $alt := .Get "alt" }}
 
-{{/*Define variables as global variables to make them accessable in this shortcode*/}}
-{{ $DarkImage := "" }}
-{{ $LightImage := "" }}
-{{ $SingleImage := "" }}
+{{/*Define sizes*/}}
+{{ $Small := 200 }}
+{{ $Medium := 600 }}
+{{ $Large := 1000 }}
+
+{{/*Define Image variables as global variables to make them easily accessible in this shortcode*/}}
+{{ $DarkImage := "" }} {{ $DarkSmallImage := "" }} {{ $DarkMediumImage := "" }} {{ $DarkLargeImage := "" }}
+{{ $LightImage := "" }} {{ $LightSmallImage := "" }} {{ $LightMediumImage := "" }} {{ $LightLargeImage := "" }}
+{{ $SingleImage := "" }} {{ $SingleSmallImage := "" }} {{ $SingleMediumImage := "" }} {{ $SingleLargeImage := "" }}
 
 {{/*Find images and update the previous Single,Dark,Light Images variables*/}}
 {{ with resources.GetMatch (print $src ".jpg") }} {{ $SingleImage = . }} {{ end }}
@@ -32,18 +37,78 @@
     {{ end }}
 {{ end }}
 
+{{/*Make different sized versions to images if applicable*/}}
+{{ with $SingleImage }}
+    {{ if gt (.Width) ($Small) }}
+        {{ with .Resize (printf "%dx" $Small) }}
+            {{ $SingleSmallImage = . }}
+        {{ end }}
+    {{ end }}
+    {{ if gt (.Width) ($Medium) }}
+        {{ with .Resize (printf "%dx" $Medium) }}
+            {{ $SingleMediumImage = . }}
+        {{ end }}
+    {{ end }}
+    {{ if gt (.Width) ($Large) }}
+        {{ with .Resize (printf "%dx" $Large) }}
+            {{ $SingleLargeImage = . }}
+        {{ end }}
+    {{ end }}
+{{ end }}
+{{ with $DarkImage }}
+    {{ if gt (.Width) ($Small) }}
+        {{ with .Resize (printf "%dx" $Small) }}
+            {{ $DarkSmallImage = . }}
+        {{ end }}
+    {{ end }}
+    {{ if gt (.Width) ($Medium) }}
+        {{ with .Resize (printf "%dx" $Medium) }}
+            {{ $DarkMediumImage = . }}
+        {{ end }}
+    {{ end }}
+    {{ if gt (.Width) ($Large) }}
+        {{ with .Resize (printf "%dx" $Large) }}
+            {{ $DarkLargeImage = . }}
+        {{ end }}
+    {{ end }}
+{{ end }}
+{{ with $LightImage }}
+    {{ if gt (.Width) ($Small) }}
+        {{ with .Resize (printf "%dx" $Small) }}
+            {{ $LightSmallImage = . }}
+        {{ end }}
+    {{ end }}
+    {{ if gt (.Width) ($Medium) }}
+        {{ with .Resize (printf "%dx" $Medium) }}
+            {{ $LightMediumImage = . }}
+        {{ end }}
+    {{ end }}
+    {{ if gt (.Width) ($Large) }}
+        {{ with .Resize (printf "%dx" $Large) }}
+            {{ $LightLargeImage = . }}
+        {{ end }}
+    {{ end }}
+{{ end }}
+
 
 {{ if $SingleImage }}
-    <img src="{{ $SingleImage.RelPermalink }}" Width="{{ $SingleImage.Width }}" height="{{ $SingleImage.Height }}" {{ with $alt }}alt="{{.}}"{{ else }}alt=""{{ end }}/>
+<picture>
+    {{ with $SingleSmallImage }}<source media='(max-width: {{ printf "%dpx" $Small}})' srcset='{{ .RelPermalink }}'>{{ end }}
+    {{ with $SingleMediumImage }}<source media='(min-width: {{ printf "%dpx" $Small}}) and (max-width: {{ printf "%dpx" $Medium}})' srcset='{{ .RelPermalink }}'>{{ end }}
+    {{ with $SingleLargeImage }}<source media='(min-width: {{ printf "%dpx" $Medium}}) and (max-width: {{ printf "%dpx" $Large}})' srcset='{{ .RelPermalink }}'>{{ end }}
+    {{ with $SingleImage }}<img src="{{ .RelPermalink }}" Width="{{ .Width }}" height="{{ .Height }}" {{ with $alt }}alt="{{.}}"{{ else }}alt=""{{ end }}/>{{ end }}
+</picture>
 {{ else }}
 <picture>
-    {{ with $SingleImage }}<source srcset="{{ .RelPermalink }}">{{ end }}
-    {{ with $DarkImage }}<source srcset="{{ .RelPermalink }}" media="(prefers-color-scheme: dark)">{{ end }}
-    {{ with $LightImage }}<source srcset="{{ .RelPermalink }}" media="(prefers-color-scheme: light)">{{ end }}
-
-    {{ with $SingleImage }}<img src="{{ .RelPermalink }}" Width="{{ .Width }}" height="{{ .Height }}" {{ with $alt }}alt="{{.}}"{{ else }}alt=""{{ end }}/>
-    {{ else with $LightImage }}<img src="{{ .RelPermalink }}" Width="{{ .Width }}" height="{{ .Height }}" {{ with $alt }}alt="{{.}}"{{ else }}alt=""{{ end }}/>
-    {{ else with $DarkImage }}<img src="{{ .RelPermalink }}" Width="{{ .Width }}" height="{{ .Height }}" {{ with $alt }}alt="{{.}}"{{ else }}alt=""{{ end }}/>
-    {{ end }}
+    {{ with $DarkSmallImage }}<source media='(max-width: {{ printf "%dpx" $Small}}) and (prefers-color-scheme: dark)' srcset='{{ .RelPermalink }}'>{{ end }}
+    {{ with $DarkMediumImage }}<source media='(min-width: {{ printf "%dpx" $Small}}) and (max-width: {{ printf "%dpx" $Medium}}) and (prefers-color-scheme: dark)' srcset='{{ .RelPermalink }}'>{{ end }}
+    {{ with $DarkLargeImage }}<source media='(min-width: {{ printf "%dpx" $Medium}}) and (max-width: {{ printf "%dpx" $Large}}) and (prefers-color-scheme: dark)' srcset='{{ .RelPermalink }}'>{{ end }}
+    {{ with $DarkImage }}<source media='(prefers-color-scheme: dark)' srcset='{{ .RelPermalink }}'>{{ end }}
+    {{ with $LightSmallImage }}<source media='(max-width: {{ printf "%dpx" $Small}}) and (prefers-color-scheme: light)' srcset='{{ .RelPermalink }}'>{{ end }}
+    {{ with $LightMediumImage }}<source media='(min-width: {{ printf "%dpx" $Small}}) and (max-width: {{ printf "%dpx" $Medium}}) and (prefers-color-scheme: light)' srcset='{{ .RelPermalink }}'>{{ end }}
+    {{ with $LightLargeImage }}<source media='(min-width: {{ printf "%dpx" $Medium}}) and (max-width: {{ printf "%dpx" $Large}}) and (prefers-color-scheme: light)' srcset='{{ .RelPermalink }}'>{{ end }}
+    {{ with $LightImage }}<source media='(prefers-color-scheme: light)' srcset='{{ .RelPermalink }}'>{{ end }}
+    {{ with $LightImage }}<img src="{{ .RelPermalink }}" Width="{{ .Width }}" height="{{ .Height }}" {{ with $alt }}alt="{{.}}"{{ else }}alt=""{{ end }}/>
+    {{ else with $DarkImage }}<img src="{{ .RelPermalink }}" Width="{{ .Width }}" height="{{ .Height }}" {{ with $alt }}alt="{{.}}"{{ else }}alt=""{{ end }}/>{{ end }}
 </picture>
 {{ end }}

--- a/layouts/shortcodes/image.html
+++ b/layouts/shortcodes/image.html
@@ -22,17 +22,17 @@
 
 {{/*Applying Image Processing*/}}
 {{ with $SingleImage }}
-    {{ with .Resize (printf "%dx%d webp" .Width .Height) }}
+    {{ with .Resize (printf "%dx%d webp q50" .Width .Height) }}
         {{ $SingleImage = . }}
     {{ end }}
 {{ end }}
 {{ with $DarkImage }}
-    {{ with .Resize (printf "%dx%d webp" .Width .Height) }}
+    {{ with .Resize (printf "%dx%d webp q50" .Width .Height) }}
         {{ $DarkImage = . }}
     {{ end }}
 {{ end }}
 {{ with $LightImage }}
-    {{ with .Resize (printf "%dx%d webp" .Width .Height) }}
+    {{ with .Resize (printf "%dx%d webp q50" .Width .Height) }}
         {{ $LightImage = . }}
     {{ end }}
 {{ end }}


### PR DESCRIPTION
## Description
This PR adds support for generating different sized-images from a single image source (if applicable), meaning if we'll have different images generated and hosted on the server, and only most optimal image (from preference to dark/light mode, to screen size) will be sent to the client.

## Performance improvements
> [!NOTE]
> This section about performance is only done on the "most benefited" page from these changes, which's the Microwin Page, as it has several high resolution images which could be optimized by providing smaller images to the user.

**Before the changes**: Transferred 754KB of data in 22 requests
**After the changes**:  Transferred 644KB of data in 24 requests

Although the requests have increased (with my limited testing, could be an error on my end), the data served to the user is much lower, about 110 KB, which's a 14.5% of bandwidth being saved everytime a new user visits the website and this page in particular.

## Screenshots
![2025_04_21-winutil_docs_site_multi_sized_images_demo](https://github.com/user-attachments/assets/e84c25f8-8d24-4cbb-90e0-037331da0e57)

## Additional Information
- Although there was a save in bandwidth, it isn't a free thing to do, as we're generating more images then ever (70 new images, was 31 before the changes, now it's 101), so please keep this in mind.
- Also, there's _still_ room for improvements, like sending lower quality images (still readable, but there will be loss in image detail) and/or using different Resampling algorithms (used when processing images) that Hugo supports, [link for more info](https://gohugo.io/content-management/image-processing/#resampling-filter).