### PR TITLE
Add Lazy Loading of images to img tag in image shortcode

### DIFF
--- a/layouts/shortcodes/image.html
+++ b/layouts/shortcodes/image.html
@@ -96,7 +96,7 @@
     {{ with $SingleSmallImage }}<source media='(max-width: {{ printf "%dpx" $Small}})' srcset='{{ .RelPermalink }}'>{{ end }}
     {{ with $SingleMediumImage }}<source media='(min-width: {{ printf "%dpx" $Small}}) and (max-width: {{ printf "%dpx" $Medium}})' srcset='{{ .RelPermalink }}'>{{ end }}
     {{ with $SingleLargeImage }}<source media='(min-width: {{ printf "%dpx" $Medium}}) and (max-width: {{ printf "%dpx" $Large}})' srcset='{{ .RelPermalink }}'>{{ end }}
-    {{ with $SingleImage }}<img src="{{ .RelPermalink }}" Width="{{ .Width }}" height="{{ .Height }}" {{ with $alt }}alt="{{.}}"{{ else }}alt=""{{ end }}/>{{ end }}
+    {{ with $SingleImage }}<img loading="lazy" src="{{ .RelPermalink }}" Width="{{ .Width }}" height="{{ .Height }}" {{ with $alt }}alt="{{.}}"{{ else }}alt=""{{ end }}/>{{ end }}
 </picture>
 {{ else }}
 <picture>
@@ -108,7 +108,7 @@
     {{ with $LightMediumImage }}<source media='(min-width: {{ printf "%dpx" $Small}}) and (max-width: {{ printf "%dpx" $Medium}}) and (prefers-color-scheme: light)' srcset='{{ .RelPermalink }}'>{{ end }}
     {{ with $LightLargeImage }}<source media='(min-width: {{ printf "%dpx" $Medium}}) and (max-width: {{ printf "%dpx" $Large}}) and (prefers-color-scheme: light)' srcset='{{ .RelPermalink }}'>{{ end }}
     {{ with $LightImage }}<source media='(prefers-color-scheme: light)' srcset='{{ .RelPermalink }}'>{{ end }}
-    {{ with $LightImage }}<img src="{{ .RelPermalink }}" Width="{{ .Width }}" height="{{ .Height }}" {{ with $alt }}alt="{{.}}"{{ else }}alt=""{{ end }}/>
-    {{ else with $DarkImage }}<img src="{{ .RelPermalink }}" Width="{{ .Width }}" height="{{ .Height }}" {{ with $alt }}alt="{{.}}"{{ else }}alt=""{{ end }}/>{{ end }}
+    {{ with $LightImage }}<img loading="lazy" src="{{ .RelPermalink }}" Width="{{ .Width }}" height="{{ .Height }}" {{ with $alt }}alt="{{.}}"{{ else }}alt=""{{ end }}/>
+    {{ else with $DarkImage }}<img loading="lazy" src="{{ .RelPermalink }}" Width="{{ .Width }}" height="{{ .Height }}" {{ with $alt }}alt="{{.}}"{{ else }}alt=""{{ end }}/>{{ end }}
 </picture>
 {{ end }}


### PR DESCRIPTION
## Description
Normally images are fetched by the browser immediately, even when it _isn't_ visible to the user, at least not yet, so by adding `loading="lazy"` attribute to `img` elements, we're telling the browser to load it when it'll be visiable to the user, which'll improve loading time performance of pages which use a lot of images which aren't immediately visible.

## Preview
[lazy_loading_images_demo.webm](https://github.com/user-attachments/assets/a531b013-3c94-4faf-b893-d88411075491)

## Additional Info
- [Documentation about Lazy Loading images - mdn web docs](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/loading)