### PR TITLE
Attempt removal of Dart-Sass Snap Installation in Site's building & deploy workflow

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -39,8 +39,6 @@ jobs:
         run: |
           wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb \
           && sudo dpkg -i ${{ runner.temp }}/hugo.deb
-      - name: Install Dart Sass
-        run: sudo snap install dart-sass
       - name: Checkout
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Description
The `Install Dart Sass` step takes the most amount of runtime when building & deploying the site, so this PR attempts at removing it completely as it isn't needed to build the site using Hugo.

## Testing
Tried running the workflow on this PR's branch manually, and it successfully built the site, but due to some deployment policies on my fork, I couldn't get it to deploy (only `main` branch can deploy site, this's the default behavior when deploying with github pages via actions).
Build Log: https://github.com/og-mrk/winutil-docs/actions/runs/14618132251/job/41011038228