### PR TITLE
Fix youtube embedded link in 'Userguide -> Tweaks' page

### DIFF
--- a/content/userguide/tweaks/_index.md
+++ b/content/userguide/tweaks/_index.md
@@ -26,7 +26,7 @@ Advanced Tweaks are intended for experienced users who have a solid understandin
 
 [O&O ShutUp10++](https://www.oo-software.com/en/shutup10) can be launched from Winutil with only one button click. It is a free privacy tool for Windows that lets users easily manage their privacy settings. It disables telemetry, controls updates, and manages app permissions to enhance security and privacy. The tool offers recommended settings for optimal privacy with just a few clicks.
 
-<iframe width="640" height="360" src="https://www.youtube.com/embed/3HvNr8eMcv0" title="O&O ShutUp10++: For Windows 10 & 11, with Dark Mode" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+{{< youtube id=3HvNr8eMcv0 loading=lazy >}}
 
 
 ### DNS


### PR DESCRIPTION
## Description
The embedded youtube link in `Userguide -> Tweaks` page is using `iframe` HTML tag directly with a fixed Width & Height, which isn't idea as problem described in Issue #47 arise, a fix to this is using the shorter and well-maintained builtin `youtube` shortcode, which's provided by Hugo (The static site generator used for building the docs site).

<details><summary><h2>Screenshots</h2></summary>
<p>

<img alt="2025_04_25-fixing_youtube_embedded_link_in_userguide_tweaks_page" src="https://github.com/user-attachments/assets/f424ee57-a7c7-4c0f-b8d8-2964464bf316">

</p>
</details> 


## Issues PR resolves
- Resolves #47

## Additional Info
- [Hugo Docs on youtube shortcode - gohugo.io](https://gohugo.io/shortcodes/youtube/)